### PR TITLE
fix email or person button in service detail tile

### DIFF
--- a/ui/src/pages/home/components/ServiceDetail/ServiceDetail.tsx
+++ b/ui/src/pages/home/components/ServiceDetail/ServiceDetail.tsx
@@ -135,7 +135,7 @@ export default function ServiceDetail(props: Props) {
         </div>
         <div className="content-connect">
           <div
-            className={`connect-detail ${!name && 'no-info'}`}
+            className={`connect-detail ${!(name || email) && 'no-info'}`}
             title={name}
             data-tooltip="Contact person email"
             onClick={handleMailClick}


### PR DESCRIPTION
contact person or email link will no longer show 'disabled' status when email is present and person name is not.