### PR TITLE
bump tools image to v0.1.2

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -26,7 +26,7 @@ ENV GOARCH=amd64
 ENV GO111MODULE=on
 RUN go build -a -tags musl -ldflags '-w' -o ./bin/api-insights github.com/cisco-developer/api-insights/api/cmd/api-insights
 
-FROM ghcr.io/cisco-developer/api-insights-tools:v0.1.1
+FROM ghcr.io/cisco-developer/api-insights-tools:v0.1.2
 ARG BUILDER_DIR=/go/src/github.com/cisco-developer/api-insights/api
 
 LABEL Description="API Insights"


### PR DESCRIPTION
tools image upgrade api-insights-openapi-rulesets to v0.1.2, which have some bug fixes.