### PR TITLE
fix compare triggering collapse on clicks in compare detail

### DIFF
--- a/ui/src/pages/compare/components/DiffList/DiffList.scss
+++ b/ui/src/pages/compare/components/DiffList/DiffList.scss
@@ -24,6 +24,7 @@
     display: inline;
     margin: 0px 1px;
     font-size: 15px;
+    cursor: pointer;
   }
 
   .row-code {

--- a/ui/src/pages/compare/components/DiffList/DiffModifiedItem/DiffModifiedItem.tsx
+++ b/ui/src/pages/compare/components/DiffList/DiffModifiedItem/DiffModifiedItem.tsx
@@ -54,7 +54,7 @@ export default function DiffModifiedItem(props: Props) {
       </div>
       {props.data.breaking && <div className="row-breaking">Breaking</div>}
       {show && (
-        <div>
+        <div onClick={(e) => { e.stopPropagation(); }}>
           <div className="detail">
             <MarkdownViewer text={props.data.message} />
           </div>


### PR DESCRIPTION
Improvement the user experience so it will not keep collapsing when user just want to copy&paste the comparison result.