### PR TITLE
change mysql to 5.7.40 to avoid sort buffer oom

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -49,7 +49,9 @@ services:
       - DB_DATABASE=api-insights
 
   mysql:
-    image: mysql:latest
+    image: mysql:5.7.40
+    # There is no official arm64 image for Apple M1 for mysql-5, so choose to use x86 version.
+    platform: "linux/amd64"
     ports:
       - "3306:3306"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,9 @@ services:
       - DB_DATABASE=api-insights
 
   mysql:
-    image: mysql:latest
+    image: mysql:5.7.40
+    # There is no official arm64 image for Apple M1 for mysql-5, so choose to use x86 version.
+    platform: "linux/amd64"
     ports:
       - "3306:3306"
     environment:


### PR DESCRIPTION
This is to avoid sort buffer oom in mysql 8.x. Please note, If you meet some issue to docker compose up this version of mysql. It probably because the old data of mysql 8.x. You need to remove them by: