### PR TITLE
backend: data compression feature.

### DIFF
--- a/api/cmd/api-insights/main.go
+++ b/api/cmd/api-insights/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cisco-developer/api-insights/api/internal/db"
 	"github.com/cisco-developer/api-insights/api/internal/endpoints"
 	"github.com/cisco-developer/api-insights/api/internal/info"
+	"github.com/cisco-developer/api-insights/api/internal/models"
 	"github.com/cisco-developer/api-insights/api/pkg/analyzer/completeness"
 	"github.com/cisco-developer/api-insights/api/pkg/analyzer/security"
 	"github.com/cisco-developer/api-insights/api/pkg/apiclarity"
@@ -62,6 +63,7 @@ func App(version string) *cli.App {
 	additionalFlags = shared.MergeFlags(additionalFlags, completeness.Flags())
 	additionalFlags = shared.MergeFlags(additionalFlags, security.Flags())
 	additionalFlags = shared.MergeFlags(additionalFlags, info.Flags())
+	additionalFlags = shared.MergeFlags(additionalFlags, models.Flags())
 
 	return shared.HTTPApp(config, additionalFlags)
 }

--- a/api/config.json
+++ b/api/config.json
@@ -15,5 +15,6 @@
   "panoptica-url": "http://localhost:9981",
   "panoptica-access-key": "",
   "panoptica-secret-key": "",
-  "auth-enabled": false
+  "auth-enabled": false,
+  "start-data-compression-at-bytes": 3145728
 }

--- a/api/internal/db/spec_dao.go
+++ b/api/internal/db/spec_dao.go
@@ -111,7 +111,7 @@ func (dao *blobSpecDAO) List(ctx context.Context, filter *ListFilter, withDoc bo
 	db := dao.client.WithContext(ctx).Table(models.SpecTableName)
 
 	if !withDoc {
-		db.Omit("doc")
+		db.Omit("doc", "doc_compressed")
 	}
 
 	query := map[string]interface{}{}

--- a/api/internal/models/spec.go
+++ b/api/internal/models/spec.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/cisco-developer/api-insights/api/pkg/utils"
 	"github.com/cisco-developer/api-insights/api/pkg/utils/shared"
 	"github.com/getkin/kin-openapi/openapi3"
 	"gopkg.in/yaml.v3"
@@ -34,19 +35,22 @@ const (
 
 // Spec represents a spec
 type Spec struct {
-	ID        string    `json:"id,omitempty" gorm:"primaryKey"`
-	Doc       SpecDoc   `json:"doc" gorm:"column:doc"`
-	DocType   string    `json:"doc_type" gorm:"column:doc_type"`
-	Revision  string    `json:"revision" gorm:"column:revision;index"`
-	Score     *int      `json:"score" gorm:"column:score"`
-	ServiceID string    `json:"service_id" gorm:"column:service_id;index"`
-	State     string    `json:"state" gorm:"column:state;index"` // Archive, Release, Development, Latest
-	Valid     string    `json:"valid" gorm:"column:valid"`
-	Version   string    `json:"version" gorm:"column:version;index"`
-	CreatedAt time.Time `json:"created_at" gorm:"column:created_at"`
-	UpdatedAt time.Time `json:"updated_at" gorm:"column:updated_at"`
+	ID            string    `json:"id,omitempty" gorm:"primaryKey"`
+	Doc           SpecDoc   `json:"doc" gorm:"column:doc"`
+	DocCompressed []byte    `json:"-" gorm:"column:doc_compressed"`
+	DocType       string    `json:"doc_type" gorm:"column:doc_type"`
+	Revision      string    `json:"revision" gorm:"column:revision;index"`
+	Score         *int      `json:"score" gorm:"column:score"`
+	ServiceID     string    `json:"service_id" gorm:"column:service_id;index"`
+	State         string    `json:"state" gorm:"column:state;index"` // Archive, Release, Development, Latest
+	Valid         string    `json:"valid" gorm:"column:valid"`
+	Version       string    `json:"version" gorm:"column:version;index"`
+	CreatedAt     time.Time `json:"created_at" gorm:"column:created_at"`
+	UpdatedAt     time.Time `json:"updated_at" gorm:"column:updated_at"`
 
 	DocOAS *openapi3.T `json:"-" gorm:"-"`
+	// internalDoc is an internal state variable for temporarily storing Spec.Doc between Spec.BeforeSave & Spec.AfterSave for data compression.
+	internalDoc SpecDoc
 }
 
 // TableName implements gorm Tabler interface
@@ -56,6 +60,46 @@ func (m *Spec) TableName() string {
 
 func (m *Spec) BeforeCreate(tx *gorm.DB) (err error) {
 	m.ID = shared.TimeUUID()
+	return
+}
+
+// BeforeSave is a hook called before creation by GORM (https://gorm.io/docs/hooks.html).
+// For handling large Spec.Doc(s), compressData conditionally compresses Spec.Doc into Spec.DocCompressed.
+func (m *Spec) BeforeSave(tx *gorm.DB) (err error) {
+
+	// Handle compression.
+	m.DocCompressed, err = compressData([]byte(*m.Doc))
+	if err != nil {
+		return err
+	} else {
+		m.internalDoc = m.Doc
+		m.Doc = nil
+	}
+
+	return
+}
+
+// AfterSave is a hook called after creation by GORM (https://gorm.io/docs/hooks.html).
+// For handling large Spec.Doc(s), resets the temporary staging of Spec.Doc.
+func (m *Spec) AfterSave(tx *gorm.DB) (err error) {
+	if m.DocCompressed != nil {
+		m.Doc = m.internalDoc
+		m.internalDoc = nil
+		m.DocCompressed = nil
+	}
+	return
+}
+
+// AfterFind is a hook called after querying by GORM (https://gorm.io/docs/hooks.html).
+// For handling large Spec.Doc(s), if Spec.DocCompressed contains the compression, decompresses it back into Spec.Doc.
+func (m *Spec) AfterFind(tx *gorm.DB) (err error) {
+	if m.DocCompressed != nil {
+		decompressed, _, err := utils.GUNZIP(m.DocCompressed)
+		if err != nil {
+			return err
+		}
+		m.Doc = NewSpecDocFromBytes(decompressed)
+	}
 	return
 }
 

--- a/api/internal/models/spec_analysis.go
+++ b/api/internal/models/spec_analysis.go
@@ -19,12 +19,12 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"time"
-
 	"github.com/cisco-developer/api-insights/api/internal/models/analyzer"
+	"github.com/cisco-developer/api-insights/api/pkg/utils"
 	"github.com/cisco-developer/api-insights/api/pkg/utils/shared"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"time"
 )
 
 const (
@@ -57,6 +57,8 @@ func (m *SpecAnalysis) BeforeCreate(tx *gorm.DB) (err error) {
 	return
 }
 
+// BeforeSave is a hook called before creation by GORM (https://gorm.io/docs/hooks.html).
+// For handling large SpecAnalysisResult.RawResult(s), compressData conditionally compresses SpecAnalysisResult.RawResult into SpecAnalysisResult.RawResultCompressed.
 func (m *SpecAnalysis) BeforeSave(tx *gorm.DB) (err error) {
 	if m.Config != nil {
 		if m.RawConfig, err = json.Marshal(m.Config); err != nil {
@@ -68,14 +70,43 @@ func (m *SpecAnalysis) BeforeSave(tx *gorm.DB) (err error) {
 			return err
 		}
 	}
+
+	// Handle compression.
+	m.RawResultCompressed, err = compressData(m.RawResult)
+	if err != nil {
+		return err
+	} else {
+		m.internalRawResult = m.RawResult
+		m.RawResult = nil
+	}
+
 	return
 }
 
+// AfterSave is a hook called after creation by GORM (https://gorm.io/docs/hooks.html).
+// For handling large SpecAnalysis.SpecAnalysisResult(s), resets the temporary staging of SpecAnalysis.SpecAnalysisResult.
+func (m *SpecAnalysis) AfterSave(tx *gorm.DB) (err error) {
+	if m.RawResultCompressed != nil {
+		m.RawResult = m.internalRawResult
+		m.internalRawResult = nil
+		m.RawResultCompressed = nil
+	}
+	return
+}
+
+// AfterFind is a hook called after querying by GORM (https://gorm.io/docs/hooks.html).
+// For handling large SpecAnalysis.SpecAnalysisResult(s), if SpecAnalysisResult.RawResultCompressed contains the compression, decompresses it back into SpecAnalysisResult.RawResult.
 func (m *SpecAnalysis) AfterFind(tx *gorm.DB) (err error) {
 	m.Result = &analyzer.Result{}
 	if m.RawConfig != nil {
 		m.Config = analyzer.Config{}
 		if err = json.Unmarshal(m.RawConfig, &m.Config); err != nil {
+			return err
+		}
+	}
+	if m.RawResultCompressed != nil {
+		m.RawResult, _, err = utils.GUNZIP(m.RawResultCompressed)
+		if err != nil {
 			return err
 		}
 	}
@@ -182,8 +213,11 @@ type SpecAnalysisConfig struct {
 }
 
 type SpecAnalysisResult struct {
-	Result    *analyzer.Result `json:"result" gorm:"-"`
-	RawResult datatypes.JSON   `json:"-" gorm:"column:result"`
+	Result              *analyzer.Result `json:"result" gorm:"-"`
+	RawResult           datatypes.JSON   `json:"-" gorm:"column:result"`
+	RawResultCompressed []byte           `json:"-" gorm:"column:result_compressed"`
+	// internalRawResult is an internal state variable for temporarily storing SpecAnalysisResult.RawResult between SpecAnalysis.BeforeSave & SpecAnalysis.AfterSave for data compression.
+	internalRawResult datatypes.JSON
 }
 
 // SpecAnalysisRequest represents a request for a SpecAnalysis

--- a/api/internal/models/spec_diff.go
+++ b/api/internal/models/spec_diff.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/cisco-developer/api-insights/api/internal/models/diff"
+	"github.com/cisco-developer/api-insights/api/pkg/utils"
 	"github.com/cisco-developer/api-insights/api/pkg/utils/shared"
 	"github.com/emicklei/go-restful/v3"
 	"gorm.io/datatypes"
@@ -46,6 +47,8 @@ type SpecDiff struct {
 	UpdatedAt time.Time `json:"updated_at" gorm:"column:updated_at"`
 }
 
+// BeforeSave is a hook called before creation by GORM (https://gorm.io/docs/hooks.html).
+// For handling large SpecDiffResult.RawResult(s), compressData conditionally compresses SpecDiffResult.RawResult into SpecDiffResult.RawResultCompressed.
 func (m *SpecDiff) BeforeSave(tx *gorm.DB) (err error) {
 	if m.Config != nil {
 		if m.RawConfig, err = json.Marshal(m.Config); err != nil {
@@ -57,13 +60,42 @@ func (m *SpecDiff) BeforeSave(tx *gorm.DB) (err error) {
 			return err
 		}
 	}
+
+	// Handle compression.
+	m.RawResultCompressed, err = compressData(m.RawResult)
+	if err != nil {
+		return err
+	} else {
+		m.internalRawResult = m.RawResult
+		m.RawResult = nil
+	}
+
 	return
 }
 
+// AfterSave is a hook called after creation by GORM (https://gorm.io/docs/hooks.html).
+// For handling large SpecDiff.SpecDiffResult(s), resets the temporary staging of SpecDiff.SpecDiffResult.
+func (m *SpecDiff) AfterSave(tx *gorm.DB) (err error) {
+	if m.RawResultCompressed != nil {
+		m.RawResult = m.internalRawResult
+		m.internalRawResult = nil
+		m.RawResultCompressed = nil
+	}
+	return
+}
+
+// AfterFind is a hook called after querying by GORM (https://gorm.io/docs/hooks.html).
+// For handling large SpecDiff.SpecDiffResult(s), if SpecDiffResult.RawResultCompressed contains the compression, decompresses it back into SpecDiffResult.RawResult.
 func (m *SpecDiff) AfterFind(tx *gorm.DB) (err error) {
 	if m.RawConfig != nil {
 		m.Config = &diff.Config{}
 		if err = json.Unmarshal(m.RawConfig, m.Config); err != nil {
+			return err
+		}
+	}
+	if m.RawResultCompressed != nil {
+		m.RawResult, _, err = utils.GUNZIP(m.RawResultCompressed)
+		if err != nil {
 			return err
 		}
 	}
@@ -169,8 +201,11 @@ type SpecDiffResponse struct {
 }
 
 type SpecDiffResult struct {
-	Result    *diff.Result   `json:"result" gorm:"-"`
-	RawResult datatypes.JSON `json:"-" gorm:"column:result"`
+	Result              *diff.Result   `json:"result" gorm:"-"`
+	RawResult           datatypes.JSON `json:"-" gorm:"column:result"`
+	RawResultCompressed []byte         `json:"-" gorm:"column:result_compressed"`
+	// internalRawResult is an internal state variable for temporarily storing SpecDiffResult.RawResult between SpecDiff.BeforeSave & SpecDiff.AfterSave for data compression.
+	internalRawResult datatypes.JSON
 }
 
 type SpecDiffRequest struct {


### PR DESCRIPTION
Utilizes GORM's hooks (https://gorm.io/docs/hooks.html) to compress (before saving) & decompress (after querying) large-sized data (size threshold determined by config `start-data-compression-at-bytes`).

`start-data-compression-at-bytes`: Value in bytes at when to compress blob; default=3145728,0=compress all,-1=no compression

Used for Spec.Doc, SpecAnalysis.SpecAnalysisResult.RawResult, SpecDiff.SpecDiffResult.RawResult.