### PR TITLE
initial support to split completeness rules; refactor spectral rules

### DIFF
--- a/api/internal/data/analyzers.json
+++ b/api/internal/data/analyzers.json
@@ -3,8 +3,32 @@
     "name_id": "completeness",
     "title": "Doc Completeness",
     "description": "Doc Completeness",
+    "status": "inactive",
+    "position": 0,
+    "config": {
+      "score_config": {
+        "analyzer_weight": 0.0
+      }
+    }
+  },
+  {
+    "name_id": "contract",
+    "title": "Contract",
+    "description": "API Contract Completeness",
     "status": "active",
     "position": 0,
+    "config": {
+      "score_config": {
+        "analyzer_weight": 0.45
+      }
+    }
+  },
+  {
+    "name_id": "documentation",
+    "title": "Documentation",
+    "description": "API Documentation Completeness",
+    "status": "active",
+    "position": 1,
     "config": {
       "score_config": {
         "analyzer_weight": 0.45
@@ -15,11 +39,11 @@
     "name_id": "guidelines",
     "title": "REST Guidelines",
     "description": "REST Guidelines",
-    "position": 1,
+    "position": 2,
     "status": "active",
     "config": {
       "score_config": {
-        "analyzer_weight": 0.45
+        "analyzer_weight": 0.0
       }
     }
   },
@@ -27,12 +51,12 @@
     "name_id": "security",
     "title": "API Security",
     "description": "API Security",
-    "position": 2,
+    "position": 3,
     "status": "inactive",
     "config": {
       "service_name_id_template": "{{ .nameID }}.api.api-insights",
       "score_config": {
-        "analyzer_weight": 0.3
+        "analyzer_weight": 0.0
       }
     }
   },
@@ -40,7 +64,7 @@
     "name_id": "inclusive-language",
     "title": "Inclusive Language",
     "description": "Detect non-inclusive language",
-    "position": 3,
+    "position": 4,
     "status": "active",
     "config": {
       "score_config": {
@@ -52,7 +76,7 @@
     "name_id": "drift",
     "title": "Drift",
     "description": "Drift",
-    "position": 4,
+    "position": 5,
     "status": "active",
     "config": {
       "score_config": {

--- a/api/internal/data/rules-contract.json
+++ b/api/internal/data/rules-contract.json
@@ -1,7 +1,7 @@
 [
   {
     "name_id": "oas2-schema",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "Validate structure of OpenAPI v2 specification.",
     "description": "Malformed OAS document, not adhering to the OpenAPI v2 specifications.",
     "mitigation": "Please fix the items identified to adhere to the OpenAPI v2 specifications. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/oas23-schema-well-formed-openapi-document)",
@@ -9,7 +9,7 @@
   },
   {
     "name_id": "oas3-schema",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "Validate structure of OpenAPI v3 specification.",
     "description": "Malformed OAS document, not adhering to the OpenAPI v3 specifications.",
     "mitigation": "Please fix the items detected to adhere to the OpenAPI v3 specifications. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/oas23-schema-well-formed-openapi-document)",
@@ -17,7 +17,7 @@
   },
   {
     "name_id": "oas3-missing-schema-definition",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "There is no schema attribute for a component.",
     "description": "Some schema definitions are missing.",
     "mitigation": "Please add schema definitions for the items detected. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/oas23-missing-schema-definition-missing-schema-definition)",
@@ -25,7 +25,7 @@
   },
   {
     "name_id": "oas2-missing-schema-definition",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "There is no schema attribute for a component.",
     "description": "Some schema definitions are missing.",
     "mitigation": "Please add schema definitions for the items detected. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/oas23-missing-schema-definition-missing-schema-definition)",
@@ -33,7 +33,7 @@
   },
   {
     "name_id": "general-schema-definition",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "Some of the defined schema use object as a final field when describing their object structure. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/general-schema-definatio-generic-schema-definition)",
     "description": "Some schemas are partially defined.",
     "mitigation": "Please fully describe the schema for the items detected as using object.",
@@ -41,7 +41,7 @@
   },
   {
     "name_id": "oas3-missing-returned-representation",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "2XX (except 204) and 4xx responses must have a response schema defined.",
     "description": "Some responses do not define a schema.",
     "mitigation": "Please add a schema for the items detected. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/oas2-3-missing-returned-representation-missing-returned-representation)",
@@ -49,7 +49,7 @@
   },
   {
     "name_id": "oas2-missing-returned-representation",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "MRR – Missing Returned Representation. 2XX (except 204) and 4xx responses must have a response schema defined",
     "description": "Some responses do not define a schema.",
     "mitigation": "Please add a schema for the items detected.  [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/oas2-3-missing-returned-representation-missing-returned-representation)",
@@ -57,7 +57,7 @@
   },
   {
     "name_id": "success-status-code",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "For every operation in the OAS document, there should be at least one success status code defined.  A successful status code is in the 1xx, 2xx or 3xx range series, and generally a 200, 201 or 204.",
     "description": "Some operations do not define a success status code.",
     "mitigation": "Please add a success status code in the 1xx, 2xx or 3xx range for the items identified. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/success-status-code-missing-success-status-code)",
@@ -65,47 +65,23 @@
   },
   {
     "name_id": "error-status-code",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "There should be at least one error status code either 4xx or 5xx.",
     "description": "Some operations do not define errors.",
     "mitigation": "Please add an error status code for the items identified. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/error-status-code-missing-error-status-code)",
     "severity": "warning"
   },
   {
-    "name_id": "description-for-every-attribute",
-    "analyzer_name_id": "completeness",
-    "title": "DEA - Descriptions for Every Attribute",
-    "description": "Some attributes do not provide a description.",
-    "mitigation": "Please add a description for the items identified. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/description-for-every-attribute-descriptions-for-every-attribute)",
-    "severity": "warning"
-  },
-  {
-    "name_id": "oas-version",
-    "analyzer_name_id": "completeness",
-    "title": "The document must be specify the OAS version it is supporting.",
-    "description": "The version of OpenAPI is not specified.",
-    "mitigation": "Please add the version of the OpenAPI specified used along the OAS document provided. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/oas-version-version-of-the-oas-is-missing)",
-    "severity": "error"
-  },
-  {
     "name_id": "oas2-meta-info",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "The following fields must be present (note: list of fields depend on the OAS version)",
     "description": "Some OpenAPI meta information are missing.",
     "mitigation": "Please add the OpenAPI attributes identified as missing and provide values for these attributes. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset)",
     "severity": "error"
   },
   {
-    "name_id": "examples-for-every-schema",
-    "analyzer_name_id": "completeness",
-    "title": "For every schema provided in the OAS document, at least one example must be present",
-    "description": "Examples are not provided for some of the schemas.",
-    "mitigation": "Please add examples for the schemas identified. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/examples-for-every-schemaexamples-for-every-schema)",
-    "severity": "warning"
-  },
-  {
     "name_id": "info-contact",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "Info object must have `contact` object.",
     "description": "Info object must have `contact` object.",
     "mitigation": "Please add missing `contact` object. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/meta-information-about-the-api-itself)",
@@ -113,7 +89,7 @@
   },
   {
     "name_id": "info-description",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "Info object must have a non-empty `description`",
     "description": "Info object must have a non-empty `description`.",
     "mitigation": "Please add missing `description`. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/meta-information-about-the-api-itself)",
@@ -121,7 +97,7 @@
   },
   {
     "name_id": "info-license",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "Info object must have `license` object.",
     "description": "Info object must have `license` object.",
     "mitigation": "Please add missing `license` object. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/meta-information-about-the-api-itself)",
@@ -129,7 +105,7 @@
   },
   {
     "name_id": "license-url",
-    "analyzer_name_id": "completeness",
+    "analyzer_name_id": "contract",
     "title": "License object must have a `url`.",
     "description": "License object must have a `url`.",
     "mitigation": "Please add missing `url`. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/meta-information-about-the-api-itself)",

--- a/api/internal/data/rules-documentation.json
+++ b/api/internal/data/rules-documentation.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name_id": "description-for-every-attribute",
+    "analyzer_name_id": "documentation",
+    "title": "DEA - Descriptions for Every Attribute",
+    "description": "Some attributes do not provide a description.",
+    "mitigation": "Please add a description for the items identified. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/description-for-every-attribute-descriptions-for-every-attribute)",
+    "severity": "warning"
+  },
+  {
+    "name_id": "examples-for-every-schema",
+    "analyzer_name_id": "documentation",
+    "title": "For every schema provided in the OAS document, at least one example must be present",
+    "description": "Examples are not provided for some of the schemas.",
+    "mitigation": "Please add examples for the schemas identified. [Reference](https://developer.cisco.com/docs/api-insights/#!documentation-completeness-ruleset/examples-for-every-schemaexamples-for-every-schema)",
+    "severity": "warning"
+  }
+]

--- a/api/internal/models/analyzer/common.go
+++ b/api/internal/models/analyzer/common.go
@@ -24,6 +24,8 @@ const (
 	InclusiveLanguage  = SpecAnalyzer("inclusive-language")
 	Drift              = SpecAnalyzer("drift")
 	Completeness       = SpecAnalyzer("completeness")
+	Contract           = SpecAnalyzer("contract")
+	Documentation      = SpecAnalyzer("documentation")
 	Security           = SpecAnalyzer("security")
 )
 

--- a/api/pkg/analyzer/contract/client.go
+++ b/api/pkg/analyzer/contract/client.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package completeness
+package contract
 
 import (
 	"github.com/cisco-developer/api-insights/api/internal/models"
@@ -24,23 +24,23 @@ import (
 	"github.com/urfave/cli/v2/altsrc"
 )
 
-// completenessRuleset represents custom spectral ruleset for completeness.
-var completenessRuleset = "node_modules/@cisco-developer/api-insights-openapi-rulesets/completeness.js"
+// contractRuleset represents custom spectral ruleset for contract.
+var contractRuleset = "node_modules/@cisco-developer/api-insights-openapi-rulesets/contract.js"
 
 func Flags() []cli.Flag {
 	return []cli.Flag{
 		altsrc.NewStringFlag(&cli.StringFlag{
-			Name:        "completeness-ruleset",
-			Usage:       "Completeness ruleset",
-			Value:       completenessRuleset,
-			Destination: &completenessRuleset,
-			EnvVars:     []string{"COMPLETENESS_RULESET"},
+			Name:        "contract-ruleset",
+			Usage:       "Contract ruleset",
+			Value:       contractRuleset,
+			Destination: &contractRuleset,
+			EnvVars:     []string{"CONTRACT_RULESET"},
 		}),
 	}
 }
 
 func NewClient() (models.SpecDocAnalyzer, error) {
-	sc, err := spectral.NewClient(completenessRuleset)
+	sc, err := spectral.NewClient(contractRuleset)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/analyzer/documentation/client.go
+++ b/api/pkg/analyzer/documentation/client.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package completeness
+package documentationp
 
 import (
 	"github.com/cisco-developer/api-insights/api/internal/models"
@@ -24,23 +24,23 @@ import (
 	"github.com/urfave/cli/v2/altsrc"
 )
 
-// completenessRuleset represents custom spectral ruleset for completeness.
-var completenessRuleset = "node_modules/@cisco-developer/api-insights-openapi-rulesets/completeness.js"
+// documentationRuleset represents custom spectral ruleset for documentation.
+var documentationRuleset = "node_modules/@cisco-developer/api-insights-openapi-rulesets/documentation.js"
 
 func Flags() []cli.Flag {
 	return []cli.Flag{
 		altsrc.NewStringFlag(&cli.StringFlag{
-			Name:        "completeness-ruleset",
-			Usage:       "Completeness ruleset",
-			Value:       completenessRuleset,
-			Destination: &completenessRuleset,
-			EnvVars:     []string{"COMPLETENESS_RULESET"},
+			Name:        "documentation-ruleset",
+			Usage:       "Documentation ruleset",
+			Value:       documentationRuleset,
+			Destination: &documentationRuleset,
+			EnvVars:     []string{"DOCUMENTATION_RULESET"},
 		}),
 	}
 }
 
 func NewClient() (models.SpecDocAnalyzer, error) {
-	sc, err := spectral.NewClient(completenessRuleset)
+	sc, err := spectral.NewClient(documentationRuleset)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/analyzer/guidelines/client.go
+++ b/api/pkg/analyzer/guidelines/client.go
@@ -17,16 +17,9 @@
 package guidelines
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"time"
-
 	"github.com/cisco-developer/api-insights/api/internal/models"
 	"github.com/cisco-developer/api-insights/api/internal/models/analyzer"
-	"github.com/cisco-developer/api-insights/api/pkg/utils/shared"
+	"github.com/cisco-developer/api-insights/api/pkg/analyzer/spectral"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
 )
@@ -46,109 +39,20 @@ func Flags() []cli.Flag {
 }
 
 func NewClient() (models.SpecDocAnalyzer, error) {
-	if err := preRunCheck(); err != nil {
+	sc, err := spectral.NewClient(guidelinesRuleset)
+	if err != nil {
 		return nil, err
 	}
-	return &cliClient{}, nil
+	return &cliClient{
+		Client: sc,
+	}, nil
 }
 
 // cliClient implements Linter.
 type cliClient struct {
+	*spectral.Client
 }
 
 func (c *cliClient) Analyze(doc models.SpecDoc, cfgMap analyzer.Config, serviceNameID *string) (*analyzer.Result, error) {
-	cfg := &analyzer.SpectralConfig{}
-	if cfgMap != nil {
-		if err := cfgMap.UnmarshalInto(cfg); err != nil {
-			return nil, fmt.Errorf("analyzer: invalid config: %v", err)
-		}
-	}
-	cfg.SetRuleset(guidelinesRuleset)
-
-	var (
-		timestamp            = fmt.Sprintf("%v", time.Now().UnixNano())
-		inputFilenamePattern = "lint-" + timestamp + "-in-*.json"
-		outputFilename       = "/tmp/lint-" + timestamp + "-out.json"
-	)
-
-	inputFile, err := os.CreateTemp("/tmp", inputFilenamePattern)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = inputFile.Close()
-		_ = os.Remove(inputFile.Name())
-	}()
-	if doc == nil || *doc == "" {
-		return nil, fmt.Errorf("doc is nil or empty")
-	}
-	_, err = inputFile.Write([]byte(*doc))
-	if err != nil {
-		return nil, err
-	}
-
-	cmd := c.commandFromOpts(context.TODO(), cfg, inputFile.Name(), outputFilename)
-
-	cmdString := cmd.String()
-	shared.LogInfof("Running CMD[%s]...", cmdString)
-	if out, err := cmd.CombinedOutput(); len(out) != 0 {
-		shared.LogErrorf("Unexpected output returned by CMD[%s] (err=%v): %v", cmdString, err, string(out))
-		//return nil, err
-		// TODO cisco-openapi-ruleset uses an outdated version of @stoplight/spectral@5.9.2, which at times validates the document incorrectly.
-		// Although it incorrectly validates the document & outputs the errors to the console, it still successfully lints & writes to the output file,
-		// so we shouldn't blindly treat console output as a fatal error, for now. Need to revisit.
-	}
-	shared.LogInfof("Successfully ran CMD[%s].", cmdString)
-
-	lintFileData, err := os.ReadFile(outputFilename)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = os.Remove(outputFilename)
-	}()
-
-	var result analyzer.SpectralResult
-	err = json.Unmarshal(lintFileData, &result)
-	if err != nil {
-		return nil, err
-	}
-	shared.LogInfof("CMD[%s] resulted in %v results.", cmdString, len(result))
-	if result == nil {
-		shared.LogErrorf("CMD[%s] failed to read results from %v.", cmdString, string(lintFileData))
-		return nil, fmt.Errorf("analyzer: failed to analyze")
-	}
-
-	return result.Result()
-}
-
-// commandFromOpts builds the `npx @cisco/cisco-openapi-ruleset ...` command.
-func (c *cliClient) commandFromOpts(ctx context.Context, cfg *analyzer.SpectralConfig, inputFilename, outputFilename string) *exec.Cmd {
-
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
-	var args []string
-
-	args = append(args, "lint")
-
-	args = append(args, "-f", "json")
-
-	if cfg.Ruleset != nil && *cfg.Ruleset != "" {
-		args = append(args, "-r", *cfg.Ruleset)
-	}
-
-	args = append(args, "-q")
-
-	args = append(args, "-o", outputFilename)
-
-	args = append(args, inputFilename)
-
-	return exec.CommandContext(ctx, "spectral", args...)
-}
-
-func preRunCheck() error {
-	// TODO Check dependencies like node & npm
-	return nil
+	return c.Client.Analyze(doc, cfgMap, serviceNameID)
 }

--- a/api/pkg/analyzer/service.go
+++ b/api/pkg/analyzer/service.go
@@ -24,6 +24,8 @@ import (
 	"github.com/cisco-developer/api-insights/api/internal/models/analyzer"
 	"github.com/cisco-developer/api-insights/api/pkg/analyzer/apiclarity"
 	"github.com/cisco-developer/api-insights/api/pkg/analyzer/completeness"
+	"github.com/cisco-developer/api-insights/api/pkg/analyzer/contract"
+	"github.com/cisco-developer/api-insights/api/pkg/analyzer/documentation"
 	"github.com/cisco-developer/api-insights/api/pkg/analyzer/guidelines"
 	"github.com/cisco-developer/api-insights/api/pkg/analyzer/security"
 	"github.com/cisco-developer/api-insights/api/pkg/analyzer/woke"
@@ -100,6 +102,10 @@ func (s *service) Analyze(req *models.SpecAnalysisRequest) (*models.SpecAnalysis
 			analyzerClient, err = guidelines.NewClient()
 		case analyzer.Completeness:
 			analyzerClient, err = completeness.NewClient()
+		case analyzer.Contract:
+			analyzerClient, err = contract.NewClient()
+		case analyzer.Documentation:
+			analyzerClient, err = documentationp.NewClient()
 		case analyzer.InclusiveLanguage:
 			analyzerClient, err = woke.NewClient()
 		case analyzer.Drift:

--- a/api/pkg/analyzer/spectral/client.go
+++ b/api/pkg/analyzer/spectral/client.go
@@ -1,0 +1,144 @@
+// Copyright 2022 Cisco Systems, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spectral
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/cisco-developer/api-insights/api/internal/models"
+	"github.com/cisco-developer/api-insights/api/internal/models/analyzer"
+	"github.com/cisco-developer/api-insights/api/pkg/utils/shared"
+)
+
+// NewClient return a spectral client for some ruleset.
+// ruleset is like "node_modules/@cisco-developer/api-insights-openapi-rulesets/api-insights-openapi-ruleset.js"
+// Client is an instance of models.SpecDocAnalyzer
+func NewClient(ruleset string) (*Client, error) {
+	if err := preRunCheck(); err != nil {
+		return nil, err
+	}
+	return &Client{
+		ruleset: ruleset,
+	}, nil
+}
+
+// Client implements Linter.
+type Client struct {
+	ruleset string
+}
+
+func (c *Client) Analyze(doc models.SpecDoc, cfgMap analyzer.Config, serviceNameID *string) (*analyzer.Result, error) {
+	cfg := &analyzer.SpectralConfig{}
+	if cfgMap != nil {
+		if err := cfgMap.UnmarshalInto(cfg); err != nil {
+			return nil, fmt.Errorf("analyzer: invalid config: %v", err)
+		}
+	}
+	cfg.SetRuleset(c.ruleset)
+
+	var (
+		timestamp            = fmt.Sprintf("%v", time.Now().UnixNano())
+		inputFilenamePattern = "lint-" + timestamp + "-in-*.json"
+		outputFilename       = "/tmp/lint-" + timestamp + "-out.json"
+	)
+
+	inputFile, err := os.CreateTemp("/tmp", inputFilenamePattern)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = inputFile.Close()
+		_ = os.Remove(inputFile.Name())
+	}()
+	if doc == nil || *doc == "" {
+		return nil, fmt.Errorf("doc is nil or empty")
+	}
+	_, err = inputFile.Write([]byte(*doc))
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := c.commandFromOpts(context.TODO(), cfg, inputFile.Name(), outputFilename)
+
+	cmdString := cmd.String()
+	shared.LogInfof("Running CMD[%s]...", cmdString)
+	if out, err := cmd.CombinedOutput(); len(out) != 0 {
+		shared.LogErrorf("Unexpected output returned by CMD[%s] (err=%v): %v", cmdString, err, string(out))
+		//return nil, err
+		// TODO cisco-openapi-ruleset uses an outdated version of @stoplight/spectral@5.9.2, which at times validates the document incorrectly.
+		// Although it incorrectly validates the document & outputs the errors to the console, it still successfully lints & writes to the output file,
+		// so we shouldn't blindly treat console output as a fatal error, for now. Need to revisit.
+	}
+	shared.LogInfof("Successfully ran CMD[%s].", cmdString)
+
+	lintFileData, err := os.ReadFile(outputFilename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = os.Remove(outputFilename)
+	}()
+
+	var result analyzer.SpectralResult
+	err = json.Unmarshal(lintFileData, &result)
+	if err != nil {
+		return nil, err
+	}
+	shared.LogInfof("CMD[%s] resulted in %v results.", cmdString, len(result))
+	if result == nil {
+		shared.LogErrorf("CMD[%s] failed to read results from %v.", cmdString, string(lintFileData))
+		return nil, fmt.Errorf("analyzer: failed to analyze")
+	}
+
+	return result.Result()
+}
+
+// commandFromOpts builds the `npx @cisco/cisco-openapi-ruleset ...` command.
+func (c *Client) commandFromOpts(ctx context.Context, cfg *analyzer.SpectralConfig, inputFilename, outputFilename string) *exec.Cmd {
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var args []string
+
+	args = append(args, "lint")
+
+	args = append(args, "-f", "json")
+
+	if cfg.Ruleset != nil && *cfg.Ruleset != "" {
+		args = append(args, "-r", *cfg.Ruleset)
+	}
+
+	args = append(args, "-q")
+
+	args = append(args, "-o", outputFilename)
+
+	args = append(args, inputFilename)
+
+	return exec.CommandContext(ctx, "spectral", args...)
+}
+
+func preRunCheck() error {
+	// TODO Check dependencies like node & npm
+	return nil
+}


### PR DESCRIPTION
Before merge this PR. the following tasks need to be done.
1. merge https://github.com/cisco-developer/api-insights-openapi-rulesets/pull/15
2. create a new npm pkg after the above pr is merged
3. create a new base tool image, and push to github registry